### PR TITLE
Add global DPP application command and fix DPP defaults

### DIFF
--- a/src/architecture.cpp
+++ b/src/architecture.cpp
@@ -1537,26 +1537,62 @@ void apply_extr(BinaryNinja::BinaryView* view, uint64_t start,
   view->Reanalyze();
 }
 
-void apply_dpp(BinaryNinja::BinaryView* view, uint64_t start, uint64_t length) {
-  int64_t dpp0, dpp1, dpp2, dpp3;
+void apply_dpp_range(BinaryNinja::BinaryView* view, uint64_t start,
+                     uint64_t length) {
+  uint32_t current_dpps[4];
+  Instruction::GetDefaultDpps(current_dpps);
 
-  BN::GetIntegerInput(dpp0, std::string("Enter DPP0 value"),
-                      std::string("DPP0:"));
-  BN::GetIntegerInput(dpp1, std::string("Enter DPP1 value"),
-                      std::string("DPP1:"));
-  BN::GetIntegerInput(dpp2, std::string("Enter DPP2 value"),
-                      std::string("DPP2:"));
-  BN::GetIntegerInput(dpp3, std::string("Enter DPP3 value"),
-                      std::string("DPP3:"));
+  std::vector<BN::FormInputField> fields;
 
-  // Try to apply to all 2-byte addresses in the specified (highlighted range)
-  uint64_t a;
-  for (a = start; a < (start + length);) {
-    BN::LogInfo("Apply DPP values to address: 0x%lx", a);
-    Instruction::SetDpps(a, dpp0, dpp1, dpp2, dpp3);
-    a += 2;
+  auto startField = BN::FormInputField::Address("Start address", view, start);
+  startField.hasDefault = true;
+  startField.addressDefault = start;
+  fields.push_back(startField);
+
+  auto lengthField = BN::FormInputField::Integer("Length (bytes)");
+  lengthField.hasDefault = true;
+  lengthField.intDefault = static_cast<int64_t>(length);
+  fields.push_back(lengthField);
+
+  fields.push_back(BN::FormInputField::Separator());
+
+  for (int i = 0; i < 4; i++) {
+    auto f = BN::FormInputField::Integer("DPP" + std::to_string(i));
+    f.hasDefault = true;
+    f.intDefault = static_cast<int64_t>(current_dpps[i]);
+    fields.push_back(f);
   }
 
+  if (!BN::GetFormInput(fields, "Apply DPP (range)")) return;
+
+  uint64_t rangeStart = fields[0].addressResult;
+  int64_t rangeLength = fields[1].intResult;
+  if (rangeLength <= 0) return;
+
+  uint64_t rangeEnd = rangeStart + static_cast<uint64_t>(rangeLength) - 2;
+
+  Instruction::SetDppsRange(rangeStart, rangeEnd, fields[3].intResult,
+                            fields[4].intResult, fields[5].intResult,
+                            fields[6].intResult);
+  view->Reanalyze();
+}
+
+void apply_dpp_global(BinaryNinja::BinaryView* view) {
+  uint32_t current_dpps[4];
+  Instruction::GetDefaultDpps(current_dpps);
+
+  std::vector<BN::FormInputField> fields;
+  for (int i = 0; i < 4; i++) {
+    auto f = BN::FormInputField::Integer("DPP" + std::to_string(i));
+    f.hasDefault = true;
+    f.intDefault = static_cast<int64_t>(current_dpps[i]);
+    fields.push_back(f);
+  }
+
+  if (!BN::GetFormInput(fields, "Apply DPP (global)")) return;
+
+  Instruction::SetDefaultDpps(fields[0].intResult, fields[1].intResult,
+                              fields[2].intResult, fields[3].intResult);
   view->Reanalyze();
 }
 
@@ -1630,27 +1666,33 @@ BINARYNINJAPLUGIN bool CorePluginInit() {
   // Register plugin commands to support manual identification of EXT/DPP values
   // for instruction lifting
   BN::PluginCommand::RegisterForRange(
-      "Apply EXTP #pag10",
+      "C166 Architecture\\Apply EXTP #pag10",
       "Highlight a range of instructions to apply EXTP #pag10 value to.",
       &C166::apply_extp_pag10, &C166::func_is_valid);
 
   BN::PluginCommand::RegisterForRange(
-      "Apply EXTS #seg8",
+      "C166 Architecture\\Apply EXTS #seg8",
       "Highlight a range of instructions to apply EXTS #seg8 value to.",
       &C166::apply_exts_seg8, &C166::func_is_valid);
 
   BN::PluginCommand::RegisterForRange(
-      "Apply EXTR", "Highlight a range of instructions to apply EXTR to.",
-      &C166::apply_extr, &C166::func_is_valid);
+      "C166 Architecture\\Apply EXTR",
+      "Highlight a range of instructions to apply EXTR to.", &C166::apply_extr,
+      &C166::func_is_valid);
 
   BN::PluginCommand::RegisterForRange(
-      "Apply DPP",
-      "Highlight a range of instructions to apply specific DPP values to.",
-      &C166::apply_dpp, &C166::func_is_valid);
+      "C166 Architecture\\Apply DPP (range)",
+      "Apply specific DPP values to a range of instructions.",
+      &C166::apply_dpp_range, &C166::func_is_valid);
 
-  // Assign Default DPP values
-  uint32_t dpp[] = {0x0, 0x0, 0x0, 0x0};
+  // Assign Default DPP values (hardware reset values)
+  uint32_t dpp[] = {0x0, 0x1, 0x2, 0x3};
   C166::Instruction::SetDefaultDpps(dpp[0], dpp[1], dpp[2], dpp[3]);
+
+  BN::PluginCommand::Register(
+      "C166 Architecture\\Apply DPP (global)",
+      "Set default DPP values for all instructions in the binary.",
+      &C166::apply_dpp_global);
 
   BN::PluginCommand::Register(
       "C166 Architecture\\Save C166 StateMap",

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -32,7 +32,7 @@ namespace C166 {
 //     disassembly (text).
 std::unordered_map<uint64_t, InstructionState> StateMap;
 std::mutex StateMapMutex;
-uint32_t default_dpp[4] = {0x0000, 0x0000, 0x0000, 0x0000};  // Reset Value(s)
+uint32_t default_dpp[4] = {0x0000, 0x0001, 0x0002, 0x0003};  // Reset Value(s)
 
 // Default Constructor
 InstructionState::InstructionState() {
@@ -52,6 +52,13 @@ void Instruction::SetDefaultDpps(uint16_t dpp0, uint16_t dpp1, uint16_t dpp2,
   default_dpp[1] = dpp1;
   default_dpp[2] = dpp2;
   default_dpp[3] = dpp3;
+}
+
+void Instruction::GetDefaultDpps(uint32_t* dpps) {
+  dpps[0] = default_dpp[0];
+  dpps[1] = default_dpp[1];
+  dpps[2] = default_dpp[2];
+  dpps[3] = default_dpp[3];
 }
 
 // Assumes DPP usage implies no EXT sequence active.
@@ -82,22 +89,22 @@ void Instruction::SetDpps(uint64_t addr, uint16_t dpp0, uint16_t dpp1,
 // Sets DPP values in a range if no EXT sequence detected.
 void Instruction::SetDppsRange(uint64_t start, uint64_t end, uint16_t dpp0,
                                uint16_t dpp1, uint16_t dpp2, uint16_t dpp3) {
-  // BN::LogInfo("util.cpp: SetDpps: addr=0x%lx", addr);
   std::lock_guard<std::mutex> guard(StateMapMutex);
 
   for (auto addr = start; addr <= end; addr += 2) {
     auto it = StateMap.find(addr);
-    // Only set DPP if we are not in an EXT sequence
-    if (it != StateMap.end() &&
-        (StateMap[addr].ext_state == ExtNoneCustomDpps ||
-         StateMap[addr].ext_state == ExtNone)) {
-      StateMap[addr].ext_state = ExtNoneCustomDpps;
-      StateMap[addr].dpp[0] = dpp0;
-      StateMap[addr].dpp[1] = dpp1;
-      StateMap[addr].dpp[2] = dpp2;
-      StateMap[addr].dpp[3] = dpp3;
+    if (it != StateMap.end()) {
+      // Only overwrite if no EXT sequence is active
+      if (it->second.ext_state == ExtNoneCustomDpps ||
+          it->second.ext_state == ExtNone) {
+        it->second.ext_state = ExtNoneCustomDpps;
+        it->second.dpp[0] = dpp0;
+        it->second.dpp[1] = dpp1;
+        it->second.dpp[2] = dpp2;
+        it->second.dpp[3] = dpp3;
+      }
     } else {
-      // Insert new element
+      // Address not in map, insert new element
       InstructionState new_insn_state;
       new_insn_state.ext_state = ExtNoneCustomDpps;
       new_insn_state.dpp[0] = dpp0;

--- a/src/util.h
+++ b/src/util.h
@@ -60,6 +60,7 @@ class Instruction {
 
   static void SetDefaultDpps(uint16_t dpp0, uint16_t dpp1, uint16_t dpp2,
                              uint16_t dpp3);
+  static void GetDefaultDpps(uint32_t *dpps);
   static void SetDpps(uint64_t addr, uint16_t dpp0, uint16_t dpp1,
                       uint16_t dpp2, uint16_t dpp3);
   static void SetDppsRange(uint64_t start, uint64_t end, uint16_t dpp0,


### PR DESCRIPTION
- Add "Apply DPP (global)" command to set default DPP values for the entire binary without requiring a range selection
- Rename "Apply DPP" to "Apply DPP (range)" and replace sequential GetIntegerInput prompts with a single GetFormInput dialog that pre-populates start/length from the selection and DPP values from current defaults
- Fix default DPP values from {0,0,0,0} to {0,1,2,3} (hardware reset)
- Fix SetDppsRange bug where the else branch unconditionally overwrote entries with active EXT sequences instead of skipping them
- Add GetDefaultDpps accessor for form pre-population

Closes #4